### PR TITLE
Fix long lines on blog posts

### DIFF
--- a/app/_layouts/post.html
+++ b/app/_layouts/post.html
@@ -27,72 +27,68 @@ post: true
     </div>
   </header>
 
-  <div class="container">
-    <div class="row">
-      <div class="col-sm-10 col-sm-offset-1">
-        <article class="post">
-          <h1><a href="{{ page.url }}">{{ page.title }} </a></h1>
-          <div class="date">{{ page.date | date_to_string }}, By {{ author.name }}</div>
-          <div class="tags">{% unless page.tags == empty %}
-            <img src="/images/post/tag-icon-small.png" class="tags-icon"/>
-            <ul class="inline">
-              {% assign tags_list = page.tags %}
-              {% include tags_list.html %}
-            </ul>
-            {% endunless %}</div>
-          <div class="post-content">
+  <div class="content-container">
+    <article class="post">
+      <h1><a href="{{ page.url }}">{{ page.title }} </a></h1>
+      <div class="date">{{ page.date | date_to_string }}, By {{ author.name }}</div>
+      <div class="tags">{% unless page.tags == empty %}
+        <img src="/images/post/tag-icon-small.png" class="tags-icon"/>
+        <ul class="inline">
+          {% assign tags_list = page.tags %}
+          {% include tags_list.html %}
+        </ul>
+        {% endunless %}</div>
+      <div class="post-content">
 
-            {{ content }}
+        {{ content }}
 
-          </div>
-        </article>
-        <section class="post-nav">
-          <div class="row">
-            <div class="col-xs-6 previous">
-              {% if page.previous %}
-              <div class="text-capitalize">
-                <a href="{{ page.previous.url }}">
-                  Previous
-                  <span class="visible-xs"> post</span>
-                </a>
-              </div>
-              <a href="{{ page.previous.url }}" class="prev-text">
-                <span class="hidden-xs">{{ page.previous.title }}</span>
-              </a>
-              {% endif %}
-            </div>
-            <div class="col-xs-6 next">
-              {% if page.next %}
-              <div class="text-capitalize">
-                <a href="{{ page.next.url }}">
-                  Next
-                  <span class="visible-xs"> post</span>
-                </a>
-              </div>
-              <a href="{{ page.next.url }}" class="next-text">
-                <span class="hidden-xs">{{ page.next.title }}</span>
-              </a>
-              {% endif %}
-            </div>
-          </div>
-        </section>
-        <section class="author-details">
-          <div class="image-wrapper">
-            <img src="/images/team/avatars/{{ author.avatar }}" class="img-circle img-responsive">
-          </div>
-          <div class="text-wrapper">
-            <span class="name">{{ author.name }}</span>
-            {% if author.twitter %}
-              <span class="twitter">(@{{ author.twitter }})</span>
-            {% endif %}
-            <div class="title">{{ author.title }}</div>
-            <div class="bio">{{ author.bio }}</div>
-          </div>
-        </section>
-        <section>
-          {% include disqus.html %}
-        </section>
       </div>
-    </div>
+    </article>
+    <section class="post-nav">
+      <div class="row">
+        <div class="col-xs-6 previous">
+          {% if page.previous %}
+          <div class="text-capitalize">
+            <a href="{{ page.previous.url }}">
+              Previous
+              <span class="visible-xs"> post</span>
+            </a>
+          </div>
+          <a href="{{ page.previous.url }}" class="prev-text">
+            <span class="hidden-xs">{{ page.previous.title }}</span>
+          </a>
+          {% endif %}
+        </div>
+        <div class="col-xs-6 next">
+          {% if page.next %}
+          <div class="text-capitalize">
+            <a href="{{ page.next.url }}">
+              Next
+              <span class="visible-xs"> post</span>
+            </a>
+          </div>
+          <a href="{{ page.next.url }}" class="next-text">
+            <span class="hidden-xs">{{ page.next.title }}</span>
+          </a>
+          {% endif %}
+        </div>
+      </div>
+    </section>
+    <section class="author-details">
+      <div class="image-wrapper">
+        <img src="/images/team/avatars/{{ author.avatar }}" class="img-circle img-responsive">
+      </div>
+      <div class="text-wrapper">
+        <span class="name">{{ author.name }}</span>
+        {% if author.twitter %}
+          <span class="twitter">(@{{ author.twitter }})</span>
+        {% endif %}
+        <div class="title">{{ author.title }}</div>
+        <div class="bio">{{ author.bio }}</div>
+      </div>
+    </section>
+    <section>
+      {% include disqus.html %}
+    </section>
   </div>
 </div>

--- a/app/_scss/pages/_post-page.scss
+++ b/app/_scss/pages/_post-page.scss
@@ -4,7 +4,15 @@
   margin: 0 auto;
 
     @include desktop {
-      max-width: 640px;
+      max-width: 660px;
+    }
+
+    @media (min-width: 1200px) {
+      max-width: 740px;
+    }
+
+    @media (min-width: 1440px) {
+      max-width: 780px;
     }
 }
 
@@ -72,6 +80,16 @@
     margin-bottom: 20px;
     font-size: 18px;
     line-height: 25px;
+
+    @include desktop {
+      font-size: 21px;
+    }
+  }
+
+  .post-content p {
+    @include desktop {
+      line-height: 1.7;
+    }
   }
 
   .caption {

--- a/app/_scss/pages/_post-page.scss
+++ b/app/_scss/pages/_post-page.scss
@@ -1,3 +1,13 @@
+.content-container {
+  padding: 10px;
+  max-width: 480px;
+  margin: 0 auto;
+
+    @include desktop {
+      max-width: 640px;
+    }
+}
+
 .post {
   h1,
   h2,
@@ -175,4 +185,3 @@
   }
 
 }
-


### PR DESCRIPTION
On mobile the max characters per line would be 55-60 characters. On desktop it would be 75-80. 
Note that it only fixes the blog posts issue (#345), not the whole site (#329).

**Mobile:** [Before](https://cloud.githubusercontent.com/assets/13344923/13839076/3086cf16-ec21-11e5-995d-5e488d974cb1.png), [After](https://cloud.githubusercontent.com/assets/13344923/13839086/39ad7cfc-ec21-11e5-990c-3f3939303be8.png)
**Desktop:** [Before](https://cloud.githubusercontent.com/assets/13344923/13839130/7cfa5e58-ec21-11e5-9c37-caea5a90bb7e.png), [After](https://cloud.githubusercontent.com/assets/13344923/13839123/7479c868-ec21-11e5-8d9e-ceb56ff42dcd.png)

