### PR TITLE
Fix hamburger menu icon too far from site's border

### DIFF
--- a/app/_scss/_header.scss
+++ b/app/_scss/_header.scss
@@ -20,6 +20,7 @@ header {
     }
 
     .navbar-toggle {
+      margin-right: 0;
       border: 0;
 
       &:hover,


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/13344923/13911957/49d5c5ae-ef40-11e5-88a6-eb1940eba3f8.png)

After:
![after](https://cloud.githubusercontent.com/assets/13344923/13911958/4d97f3c4-ef40-11e5-9490-eb78284ee8d7.png)


