### PR TITLE
Blog page title fix

### DIFF
--- a/app/_includes/title.html
+++ b/app/_includes/title.html
@@ -1,6 +1,6 @@
 {% case page.title %}
   {% when 'Blog' %}
-    {% capture title %}"Blog page - {{ paginator.page }} | Gizra"{% endcapture %}
+    {% capture title %}Gizra's Blog{% if paginator.page > 1 %} | Page {{ paginator.page }}{% endif %}{% endcapture %}
   {% else %}
     {% assign title = page.title %}
 {% endcase %}


### PR DESCRIPTION
#343
First blog page title is "Gizra's Blog". 
From the 2nd page it includes the page number - i.e. "Gizra's Blog | Page 2".