### PR TITLE
Improved Google Fonts font request

### DIFF
--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -32,12 +32,12 @@
       <!-- build:css({app,.tmp}) /css/main.css -->
       <link rel="stylesheet" href="/css/main.css">
       <!-- endbuild -->
-      <link href='http://fonts.googleapis.com/css?family=Abril+Fatface' rel='stylesheet' type='text/css'>
+      <link href='http://fonts.googleapis.com/css?family=Abril+Fatface&text=gizra' rel='stylesheet' type='text/css'>
       <link href='https://fonts.googleapis.com/css?family=Hind:400,600,300,500' rel='stylesheet' type='text/css'>
       <link href='https://fonts.googleapis.com/css?family=Raleway:400,300,600,800' rel='stylesheet' type='text/css'>
       <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
       {% include ga.html %}
-      
+
       <!-- Begin Inspectlet Embed Code -->
       <script type="text/javascript" id="inspectletjs">
       window.__insp = window.__insp || [];
@@ -48,7 +48,7 @@
       })();
       </script>
       <!-- End Inspectlet Embed Code -->
-      
+
     </head>
     <body>
 


### PR DESCRIPTION
`Abril Fatface` is being used only by Gizra's logo ( g i z r a characters ), so these are the only required font characters.