### PR TITLE
Accessbility fixes

### DIFF
--- a/app/_includes/post_teaser.html
+++ b/app/_includes/post_teaser.html
@@ -32,7 +32,7 @@
       <p class="name">By {{ author.name }} </p>
       {% endif %}
       <a href="{{ post.url }}">
-        <img src="/images/team/avatars/{{ author.avatar }}" class="img-responsive img-circle avatar grayscale">
+        <img src="/images/team/avatars/{{ author.avatar }}" class="img-responsive img-circle avatar grayscale" alt="">>
       </a>
       <p class="date">{{ post.date | date: "%b %-d, %Y" }}</p>
     </div>

--- a/app/_includes/testimonials.html
+++ b/app/_includes/testimonials.html
@@ -14,7 +14,7 @@
           <div class="carousel-inner" role="listbox">
             <div class="item active">
               <div>
-                <img src="/images/homepage/testimonials/harvard-logo.png" title="OpenScholar">
+                <img src="/images/homepage/testimonials/harvard-logo.png" alt="OpenScholar">
                 <p class="blockquote">
                   We had them work with complex requirements and Gizra has always delivered high-quality
                   solutions focusing not just on the output but also on future maintainability and best practices.
@@ -26,7 +26,7 @@
             </div>
             <div class="item">
               <div>
-                <img src="/images/homepage/testimonials/acquia-black.png" title="Acquia">
+                <img src="/images/homepage/testimonials/acquia-black.png" alt="Acquia">
                 <p class="blockquote">
                   I consistently recommend Gizra as a top choice for anyone looking for complex Drupal development work done right.
                 </p>
@@ -37,7 +37,7 @@
             </div>
             <div class="item">
               <div>
-                <img src="/images/homepage/testimonials/national-library.png" title="The National Library of Israel">
+                <img src="/images/homepage/testimonials/national-library.png" alt="The National Library of Israel">
                 <p class="blockquote">
                   Gizra translated our wishes to technical specifications and to a working product and did
                   so in a timely manner and within budget. Not less important, they remained attentive and captured the
@@ -55,4 +55,3 @@
     </div>
   </div>
 </section>
-

--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">

--- a/app/_scss/_about.scss
+++ b/app/_scss/_about.scss
@@ -74,7 +74,6 @@
 @include desktop {
 
   #about {
-    text-align: justify;
 
     #gizra-way {
       margin-top: 45px;
@@ -101,7 +100,7 @@
     margin-top: 35px;
     margin-bottom: 10px;
     padding: 20px 0;
-    
+
     .mobile-title {
       margin-bottom: 17px;
     }


### PR DESCRIPTION
Should fix most of the problems mentioned in #338, apart from _**"Blank link text found"**_:
I think we should keep short descriptions of the posts and include it as the link title. Also good for SEO, as all the posts descriptions is currently `<meta name="description" content="">`